### PR TITLE
WEB: API route 기본 파일들 생성완료

### DIFF
--- a/BE/.eslintrc.json
+++ b/BE/.eslintrc.json
@@ -1,7 +1,7 @@
 { 
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
-    "project": "./tsconfig.json"
+    "project": "./BE/tsconfig.json"
   },
   "env": {
     "node": true
@@ -9,6 +9,23 @@
   "extends": ["airbnb-base","plugin:@typescript-eslint/recommended", "plugin:prettier/recommended", "prettier/@typescript-eslint"],
   "ignorePatterns": ["node_modules/","build/"],
   "rules": {
-      "prettier/prettier": "error"
-  }
+      "prettier/prettier": "error",
+      "import/extensions": [
+        "error",
+        "ignorePackages",
+        {
+          "js": "never",
+          "jsx": "never",
+          "ts": "never",
+          "tsx": "never"
+        }
+     ]
+  },
+  "settings": { 
+    "import/resolver": { 
+      "node": { 
+        "extensions": [".js", ".jsx", ".ts", ".tsx"] 
+        } 
+      } 
+    }
 }

--- a/BE/.eslintrc.json
+++ b/BE/.eslintrc.json
@@ -9,7 +9,7 @@
   "extends": ["airbnb-base","plugin:@typescript-eslint/recommended", "plugin:prettier/recommended", "prettier/@typescript-eslint"],
   "ignorePatterns": ["node_modules/","build/"],
   "rules": {
-      "prettier/prettier": "error",
+      "prettier/prettier": ["error",{ "endOfLine": "auto"}],
       "import/extensions": [
         "error",
         "ignorePackages",

--- a/BE/.gitignore
+++ b/BE/.gitignore
@@ -115,3 +115,4 @@ dist
 build
 
 # End of https://www.toptal.com/developers/gitignore/api/node
+.gitmessage.txt

--- a/BE/package-lock.json
+++ b/BE/package-lock.json
@@ -153,7 +153,6 @@
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
       "integrity": "sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==",
-      "dev": true,
       "requires": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -163,7 +162,6 @@
       "version": "3.4.33",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.33.tgz",
       "integrity": "sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -172,7 +170,6 @@
       "version": "4.17.8",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.8.tgz",
       "integrity": "sha512-wLhcKh3PMlyA2cNAB9sjM1BntnhPMiM0JOBwPBqttjHev2428MLEB4AYVN+d8s2iyCVZac+o41Pflm/ZH5vLXQ==",
-      "dev": true,
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "*",
@@ -184,11 +181,19 @@
       "version": "4.17.13",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.13.tgz",
       "integrity": "sha512-RgDi5a4nuzam073lRGKTUIaL3eF2+H7LJvJ8eUnCI0wA6SNjXc44DCmWNiTLs/AZ7QlsFWZiw/gTG3nSQGL0fA==",
-      "dev": true,
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",
         "@types/range-parser": "*"
+      }
+    },
+    "@types/express-session": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@types/express-session/-/express-session-1.17.0.tgz",
+      "integrity": "sha512-OQEHeBFE1UhChVIBhRh9qElHUvTp4BzKKHxMDkGHT7WuYk5eL93hPG7D8YAIkoBSbhNEY0RjreF15zn+U0eLjA==",
+      "requires": {
+        "@types/express": "*",
+        "@types/node": "*"
       }
     },
     "@types/json-schema": {
@@ -206,32 +211,54 @@
     "@types/mime": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.3.tgz",
-      "integrity": "sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q==",
-      "dev": true
+      "integrity": "sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q=="
     },
     "@types/node": {
       "version": "14.14.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.5.tgz",
-      "integrity": "sha512-H5Wn24s/ZOukBmDn03nnGTp18A60ny9AmCwnEcgJiTgSGsCO7k+NWP7zjCCbhlcnVCoI+co52dUAt9GMhOSULw==",
-      "dev": true
+      "integrity": "sha512-H5Wn24s/ZOukBmDn03nnGTp18A60ny9AmCwnEcgJiTgSGsCO7k+NWP7zjCCbhlcnVCoI+co52dUAt9GMhOSULw=="
+    },
+    "@types/passport": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.4.tgz",
+      "integrity": "sha512-h5OfAbfBBYSzjeU0GTuuqYEk9McTgWeGQql9g3gUw2/NNCfD7VgExVRYJVVeU13Twn202Mvk9BT0bUrl30sEgA==",
+      "requires": {
+        "@types/express": "*"
+      }
+    },
+    "@types/passport-local": {
+      "version": "1.0.33",
+      "resolved": "https://registry.npmjs.org/@types/passport-local/-/passport-local-1.0.33.tgz",
+      "integrity": "sha512-+rn6ZIxje0jZ2+DAiWFI8vGG7ZFKB0hXx2cUdMmudSWsigSq6ES7Emso46r4HJk0qCgrZVfI8sJiM7HIYf4SbA==",
+      "requires": {
+        "@types/express": "*",
+        "@types/passport": "*",
+        "@types/passport-strategy": "*"
+      }
+    },
+    "@types/passport-strategy": {
+      "version": "0.2.35",
+      "resolved": "https://registry.npmjs.org/@types/passport-strategy/-/passport-strategy-0.2.35.tgz",
+      "integrity": "sha512-o5D19Jy2XPFoX2rKApykY15et3Apgax00RRLf0RUotPDUsYrQa7x4howLYr9El2mlUApHmCMv5CZ1IXqKFQ2+g==",
+      "requires": {
+        "@types/express": "*",
+        "@types/passport": "*"
+      }
     },
     "@types/qs": {
       "version": "6.9.5",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.5.tgz",
-      "integrity": "sha512-/JHkVHtx/REVG0VVToGRGH2+23hsYLHdyG+GrvoUGlGAd0ErauXDyvHtRI/7H7mzLm+tBCKA7pfcpkQ1lf58iQ==",
-      "dev": true
+      "integrity": "sha512-/JHkVHtx/REVG0VVToGRGH2+23hsYLHdyG+GrvoUGlGAd0ErauXDyvHtRI/7H7mzLm+tBCKA7pfcpkQ1lf58iQ=="
     },
     "@types/range-parser": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
-      "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==",
-      "dev": true
+      "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
     },
     "@types/serve-static": {
       "version": "1.13.6",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.6.tgz",
       "integrity": "sha512-nuRJmv7jW7VmCVTn+IgYDkkbbDGyIINOeu/G0d74X3lm6E5KfMeQPJhxIt1ayQeQB3cSxvYs1RA/wipYoFB4EA==",
-      "dev": true,
       "requires": {
         "@types/mime": "*",
         "@types/node": "*"
@@ -1602,6 +1629,46 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "express-session": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.17.1.tgz",
+      "integrity": "sha512-UbHwgqjxQZJiWRTMyhvWGvjBQduGCSBDhhZXYenziMFjxst5rMV+aJZ6hKPHZnPyHGsrqRICxtX8jtEbm/z36Q==",
+      "requires": {
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-headers": "~1.0.2",
+        "parseurl": "~1.3.3",
+        "safe-buffer": "5.2.0",
+        "uid-safe": "~2.1.5"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
         }
       }
     },
@@ -3201,6 +3268,11 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
     },
+    "random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha1-T2ih3Arli9P7lYSMMDJNt11kNgs="
+    },
     "range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -3836,6 +3908,14 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
       "integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
       "dev": true
+    },
+    "uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "requires": {
+        "random-bytes": "~1.0.0"
+      }
     },
     "uid2": {
       "version": "0.0.3",

--- a/BE/package.json
+++ b/BE/package.json
@@ -25,10 +25,15 @@
     "typescript": "^4.0.5"
   },
   "dependencies": {
+    "@types/express-session": "^1.17.0",
+    "@types/passport": "^1.0.4",
+    "@types/passport-local": "^1.0.33",
     "bcrypt": "^5.0.0",
+    "body-parser": "^1.19.0",
     "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
+    "express-session": "^1.17.1",
     "helmet": "^4.1.1",
     "jsonwebtoken": "^8.5.1",
     "morgan": "^1.10.0",

--- a/BE/src/controller/authController.ts
+++ b/BE/src/controller/authController.ts
@@ -1,0 +1,20 @@
+import { Request, Response } from "express";
+import passport from "passport";
+
+function login(req: Request, res: Response): void {
+  passport.authenticate("local", (err, userResult) => {
+    if (err || !userResult) {
+      return res.status(400).json({
+        message: "Something is not right",
+        user: userResult,
+      });
+    }
+    req.login(userResult, (error) => {
+      if (error) {
+        return res.send(error);
+      }
+      return res.json({ userResult });
+    });
+  })(req, res);
+}
+export default { login };

--- a/BE/src/index.ts
+++ b/BE/src/index.ts
@@ -2,6 +2,8 @@ import express from "express";
 import index from "./route/index";
 import auth from "./route/auth";
 import milestone from "./route/milestone";
+import label from "./route/label";
+import issue from "./route/issue";
 
 class App {
   public application: express.Application;
@@ -15,5 +17,7 @@ const app = new App().application;
 app.use("/", index);
 app.use("/auth", auth);
 app.use("/milestone", milestone);
+app.use("/label", label);
+app.use("/issue", issue);
 
 app.listen(4000, () => console.log("start"));

--- a/BE/src/index.ts
+++ b/BE/src/index.ts
@@ -1,5 +1,6 @@
 import express from "express";
 import index from "./route/index";
+import auth from "./route/auth";
 
 class App {
   public application: express.Application;
@@ -11,4 +12,6 @@ class App {
 const app = new App().application;
 
 app.use("/", index);
+app.use("auth", auth);
+
 app.listen(4000, () => console.log("start"));

--- a/BE/src/index.ts
+++ b/BE/src/index.ts
@@ -1,10 +1,16 @@
 import express from "express";
+import passport from "passport";
+import session from "express-session";
+import bodyParser from "body-parser";
+
 import index from "./route/index";
 import auth from "./route/auth";
 import milestone from "./route/milestone";
 import label from "./route/label";
 import issue from "./route/issue";
 import event from "./route/event";
+
+import Passport from "./passport/passport";
 
 class App {
   public application: express.Application;
@@ -14,6 +20,20 @@ class App {
   }
 }
 const app = new App().application;
+const passportConfig: Passport = new Passport();
+
+app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({ extended: false }));
+app.use(passport.initialize());
+app.use(passport.session());
+app.use(
+  session({
+    secret: `@#@$MYSIGN#@$#$`,
+    resave: false,
+    saveUninitialized: true,
+  })
+);
+passportConfig.config();
 
 app.use("/", index);
 app.use("/auth", auth);

--- a/BE/src/index.ts
+++ b/BE/src/index.ts
@@ -4,6 +4,7 @@ import auth from "./route/auth";
 import milestone from "./route/milestone";
 import label from "./route/label";
 import issue from "./route/issue";
+import event from "./route/event";
 
 class App {
   public application: express.Application;
@@ -19,5 +20,6 @@ app.use("/auth", auth);
 app.use("/milestone", milestone);
 app.use("/label", label);
 app.use("/issue", issue);
+app.use("/event", event);
 
 app.listen(4000, () => console.log("start"));

--- a/BE/src/index.ts
+++ b/BE/src/index.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import index from "./route/index";
 import auth from "./route/auth";
+import milestone from "./route/milestone";
 
 class App {
   public application: express.Application;
@@ -12,6 +13,7 @@ class App {
 const app = new App().application;
 
 app.use("/", index);
-app.use("auth", auth);
+app.use("/auth", auth);
+app.use("/milestone", milestone);
 
 app.listen(4000, () => console.log("start"));

--- a/BE/src/index.ts
+++ b/BE/src/index.ts
@@ -1,4 +1,5 @@
 import express from "express";
+import index from "./route/index";
 
 class App {
   public application: express.Application;
@@ -8,7 +9,6 @@ class App {
   }
 }
 const app = new App().application;
-app.get("/", (req: express.Request, res: express.Response) => {
-  res.send("start");
-});
+
+app.use("/", index);
 app.listen(4000, () => console.log("start"));

--- a/BE/src/passport/passport.ts
+++ b/BE/src/passport/passport.ts
@@ -1,0 +1,32 @@
+import passport from "passport";
+import passportLocal from "passport-local";
+
+const LocalStrategy = passportLocal.Strategy;
+
+class Passport {
+  public config = () => {
+    // Local Strategy
+    passport.use(
+      new LocalStrategy(
+        {
+          usernameField: "userID",
+          passwordField: "password",
+        },
+        async (userId: string, passWord: string, done) => {
+          const user = { userID: userId, password: passWord };
+          return done(null, user, { message: "Logged In Successfully" });
+        }
+      )
+    );
+
+    passport.serializeUser<unknown, unknown>((user, done) => {
+      done(null, user);
+    });
+
+    passport.deserializeUser(function (user, done) {
+      done(null, user);
+    });
+  };
+}
+
+export default Passport;

--- a/BE/src/route/auth.ts
+++ b/BE/src/route/auth.ts
@@ -1,15 +1,18 @@
 import express, { Request, Response, NextFunction } from "express";
+import authController from "../controller/authController";
 
 const router = express.Router();
 
-router.post("/login", (req: Request, res: Response, next: NextFunction) => {
-  res.send("login");
-});
+router.post("/login", authController.login);
+
 router.get("/logout", (req: Request, res: Response, next: NextFunction) => {
   res.send("logout");
 });
 router.post("/register", (req: Request, res: Response, next: NextFunction) => {
   res.send("register");
+});
+router.get("/users", (req: Request, res: Response, next: NextFunction) => {
+  res.send("users");
 });
 
 export = router;

--- a/BE/src/route/auth.ts
+++ b/BE/src/route/auth.ts
@@ -1,0 +1,15 @@
+import express, { Request, Response, NextFunction } from "express";
+
+const router = express.Router();
+
+router.post("/login", (req: Request, res: Response, next: NextFunction) => {
+  res.send("login");
+});
+router.get("/logout", (req: Request, res: Response, next: NextFunction) => {
+  res.send("logout");
+});
+router.post("/register", (req: Request, res: Response, next: NextFunction) => {
+  res.send("register");
+});
+
+export = router;

--- a/BE/src/route/comment.ts
+++ b/BE/src/route/comment.ts
@@ -1,0 +1,17 @@
+import express, { Request, Response, NextFunction } from "express";
+
+const router = express.Router();
+
+router.get("/:id", (req: Request, res: Response, next: NextFunction) => {
+  res.send("comment get");
+});
+router.post("/", (req: Request, res: Response, next: NextFunction) => {
+  res.send("comment post");
+});
+router.patch("/", (req: Request, res: Response, next: NextFunction) => {
+  res.send("comment patch");
+});
+router.delete("/", (req: Request, res: Response, next: NextFunction) => {
+  res.send("comment delete");
+});
+export = router;

--- a/BE/src/route/event.ts
+++ b/BE/src/route/event.ts
@@ -1,0 +1,9 @@
+import express, { Request, Response, NextFunction } from "express";
+
+const router = express.Router();
+
+router.get("/", (req: Request, res: Response, next: NextFunction) => {
+  res.send("event get");
+});
+
+export = router;

--- a/BE/src/route/index.ts
+++ b/BE/src/route/index.ts
@@ -1,0 +1,9 @@
+import express, { Request, Response, NextFunction } from "express";
+
+const router = express.Router();
+
+router.get("/", (req: Request, res: Response, next: NextFunction) => {
+  res.send("world");
+});
+
+export = router;

--- a/BE/src/route/issue.ts
+++ b/BE/src/route/issue.ts
@@ -1,0 +1,20 @@
+import express, { Request, Response, NextFunction } from "express";
+
+const router = express.Router();
+
+router.get("/", (req: Request, res: Response, next: NextFunction) => {
+  res.send("issue total get");
+});
+router.get("/:id", (req: Request, res: Response, next: NextFunction) => {
+  res.send("issue single get");
+});
+router.post("/", (req: Request, res: Response, next: NextFunction) => {
+  res.send("issue post");
+});
+router.patch("/", (req: Request, res: Response, next: NextFunction) => {
+  res.send("issue patch");
+});
+router.get("/statechange/:id", (req: Request, res: Response, next: NextFunction) => {
+  res.send("issue State Change");
+});
+export = router;

--- a/BE/src/route/label.ts
+++ b/BE/src/route/label.ts
@@ -1,0 +1,17 @@
+import express, { Request, Response, NextFunction } from "express";
+
+const router = express.Router();
+
+router.get("/", (req: Request, res: Response, next: NextFunction) => {
+  res.send("label get");
+});
+router.post("/", (req: Request, res: Response, next: NextFunction) => {
+  res.send("label post");
+});
+router.patch("/", (req: Request, res: Response, next: NextFunction) => {
+  res.send("label patch");
+});
+router.delete("/", (req: Request, res: Response, next: NextFunction) => {
+  res.send("label delete");
+});
+export = router;

--- a/BE/src/route/milestone.ts
+++ b/BE/src/route/milestone.ts
@@ -1,0 +1,17 @@
+import express, { Request, Response, NextFunction } from "express";
+
+const router = express.Router();
+
+router.get("/", (req: Request, res: Response, next: NextFunction) => {
+  res.send("milestone get");
+});
+router.post("/", (req: Request, res: Response, next: NextFunction) => {
+  res.send("milesone post");
+});
+router.patch("/", (req: Request, res: Response, next: NextFunction) => {
+  res.send("milesone patch");
+});
+router.delete("/", (req: Request, res: Response, next: NextFunction) => {
+  res.send("milesone delete");
+});
+export = router;


### PR DESCRIPTION
API 에 필요한 기본 route 파일들을 만들었습니다 . ( index + API항목 6개 )

1. auth
2. comment
3. event
4. issue
5. label
6. milestone

(그 외 수정된 ESLint 설정 파일도 포함했습니다. )

API 명세 Get 이 아닌 메소드를 사용할 때, 파라매터에 id 를 넣는 경우는 

모두 파라매터 부분을 제거하고 body 에 넣어 보내도록 변경했습니다.

이에 맞추어서 API 명세서도 수정했습니다.

이에 맞추어서 ./index.ts 도 수정했습니다.