### PR TITLE
APP: LoginPage Sign In with Github 구현

### DIFF
--- a/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		BB41E027254963FA008245A3 /* APIConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB41E026254963FA008245A3 /* APIConfiguration.swift */; };
 		BB41E02B2549655B008245A3 /* SignInEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB41E02A2549655B008245A3 /* SignInEndPoint.swift */; };
 		BB52170F254A81D8008455D4 /* UserTestModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB52170E254A81D8008455D4 /* UserTestModel.swift */; };
+		BB52171B254A9EAF008455D4 /* OAuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB52171A254A9EAF008455D4 /* OAuthManager.swift */; };
 		BBCC49ED2547E8F300FAB2F4 /* SignInViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBCC49EC2547E8F300FAB2F4 /* SignInViewController.swift */; };
 		BBCC49F32547E9FD00FAB2F4 /* UIViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBCC49F22547E9FD00FAB2F4 /* UIViewExtension.swift */; };
 		BBCC4A032547FCF800FAB2F4 /* SignUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBCC4A022547FCF800FAB2F4 /* SignUpViewController.swift */; };
@@ -64,6 +65,7 @@
 		BB41E026254963FA008245A3 /* APIConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIConfiguration.swift; sourceTree = "<group>"; };
 		BB41E02A2549655B008245A3 /* SignInEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInEndPoint.swift; sourceTree = "<group>"; };
 		BB52170E254A81D8008455D4 /* UserTestModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserTestModel.swift; sourceTree = "<group>"; };
+		BB52171A254A9EAF008455D4 /* OAuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthManager.swift; sourceTree = "<group>"; };
 		BBCC49EC2547E8F300FAB2F4 /* SignInViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInViewController.swift; sourceTree = "<group>"; };
 		BBCC49F22547E9FD00FAB2F4 /* UIViewExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewExtension.swift; sourceTree = "<group>"; };
 		BBCC4A022547FCF800FAB2F4 /* SignUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpViewController.swift; sourceTree = "<group>"; };
@@ -97,6 +99,7 @@
 				BBCC49EC2547E8F300FAB2F4 /* SignInViewController.swift */,
 				BBCC4A122548204200FAB2F4 /* SignInInteractor.swift */,
 				BB41E02A2549655B008245A3 /* SignInEndPoint.swift */,
+				BB52171A254A9EAF008455D4 /* OAuthManager.swift */,
 			);
 			path = SignIn;
 			sourceTree = "<group>";
@@ -360,6 +363,7 @@
 				BBCC49F32547E9FD00FAB2F4 /* UIViewExtension.swift in Sources */,
 				BBCC49ED2547E8F300FAB2F4 /* SignInViewController.swift in Sources */,
 				708EFEF22546DBC9009D9DEC /* ViewController.swift in Sources */,
+				BB52171B254A9EAF008455D4 /* OAuthManager.swift in Sources */,
 				BB41E027254963FA008245A3 /* APIConfiguration.swift in Sources */,
 				701343C125493A160044080A /* NetworkManager.swift in Sources */,
 				708EFEEE2546DBC9009D9DEC /* AppDelegate.swift in Sources */,

--- a/iOS/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
+++ b/iOS/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="8q5-Xp-b3w">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="RoK-7g-YYk">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
@@ -28,18 +28,18 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="551" y="123"/>
+            <point key="canvasLocation" x="1492" y="122.66009852216749"/>
         </scene>
         <!--Sign In View Controller-->
         <scene sceneID="AhX-wd-i4K">
             <objects>
-                <viewController id="8q5-Xp-b3w" customClass="SignInViewController" customModule="IssueTracker" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="SignInViewController" id="8q5-Xp-b3w" customClass="SignInViewController" customModule="IssueTracker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="bgY-cH-2Xg">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Xa9-MQ-cEJ">
-                                <rect key="frame" x="0.0" y="44" width="375" height="734"/>
+                                <rect key="frame" x="0.0" y="88" width="375" height="690"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="L6K-ow-iCS" userLabel="Content View">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="730"/>
@@ -231,6 +231,7 @@
                             <constraint firstItem="Xa9-MQ-cEJ" firstAttribute="leading" secondItem="2Ux-DR-s1k" secondAttribute="leading" id="pzC-nD-zBX"/>
                         </constraints>
                     </view>
+                    <navigationItem key="navigationItem" id="koI-0A-qvH"/>
                     <connections>
                         <outlet property="idTextField" destination="m6l-g3-sQv" id="wOK-h3-wPs"/>
                         <outlet property="pwTextField" destination="zv2-1n-DnL" id="ffF-UF-q7D"/>
@@ -238,18 +239,18 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="zEh-cz-ZMo" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-784.79999999999995" y="122.66009852216749"/>
+            <point key="canvasLocation" x="157.59999999999999" y="122.66009852216749"/>
         </scene>
         <!--Sign Up View Controller-->
         <scene sceneID="ytn-bN-4fp">
             <objects>
                 <viewController id="AH7-Vn-m2L" customClass="SignUpViewController" customModule="IssueTracker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="HLg-VY-kLa">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="758"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Xwo-fX-nnR">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="724"/>
+                                <rect key="frame" x="0.0" y="88" width="375" height="690"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CaL-gw-jfx" userLabel="Content View">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="762"/>
@@ -426,7 +427,25 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="7jz-cc-ISk" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-785" y="911"/>
+            <point key="canvasLocation" x="158" y="832"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="0KD-1E-U1p">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="RoK-7g-YYk" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="RsG-wH-xuc">
+                        <rect key="frame" x="0.0" y="44" width="375" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="8q5-Xp-b3w" kind="relationship" relationship="rootViewController" id="zaH-29-Ywu"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="aep-Io-TAI" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-687" y="123"/>
         </scene>
     </scenes>
     <resources>

--- a/iOS/IssueTracker/IssueTracker/SignIn/OAuthManager.swift
+++ b/iOS/IssueTracker/IssueTracker/SignIn/OAuthManager.swift
@@ -1,0 +1,42 @@
+//
+//  OAuthManager.swift
+//  IssueTracker
+//
+//  Created by 송민관 on 2020/10/29.
+//
+
+import Foundation
+import AuthenticationServices
+
+final class OAuthManager {
+    private let presentationContextProvider: ASWebAuthenticationPresentationContextProviding
+    private let callbackScheme: String
+    private let tokenQuery: String = "token"
+    private var webAuthSession: ASWebAuthenticationSession?
+    
+    init(provider: ASWebAuthenticationPresentationContextProviding) {
+        presentationContextProvider = provider
+        callbackScheme = ""
+    }
+    
+    func reqeustToken(url: String, handler: @escaping (String) -> Void) {
+        guard let url = try? url.asURL() else { return }
+        
+        
+        
+        let session = ASWebAuthenticationSession(url: url, callbackURLScheme: callbackScheme) { callBack, error in
+//            guard error == nil, let callbackURL = callBack else {
+//                return
+//            }
+//            let queryItems = URLComponents(string: callbackURL.absoluteString)?.queryItems
+//
+//            guard let token = queryItems?.filter({ $0.name == self.tokenQuery }).first?.value else {
+//                return
+//            }
+//            handler(token)
+        }
+        
+        session.presentationContextProvider = presentationContextProvider
+        session.start()
+    }
+}

--- a/iOS/IssueTracker/IssueTracker/SignIn/SignInViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/SignIn/SignInViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import AuthenticationServices
 
 final class SignInViewController: UIViewController {
     
@@ -20,6 +21,16 @@ final class SignInViewController: UIViewController {
         super.viewDidLoad()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(true)
+        navigationController?.navigationBar.isHidden = true
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillAppear(true)
+        navigationController?.navigationBar.isHidden = false
+    }
+    
     // MARK: Action Functions
     
     @IBAction func signInTouched(_ sender: UIButton) {
@@ -30,10 +41,24 @@ final class SignInViewController: UIViewController {
     // TODO: 로그인 실패/성공 : toast
     
     @IBAction func signInWithGitHubTouched(_ sender: UIButton) {
-        // TODO: 깃허브 로그인 검증
+        let path = "http://101.101.210.34:3000/auth/github"
+//        let path = "https://github.com/login/oauth/authorize"
+        OAuthManager.init(provider: self).reqeustToken(url: path) { token in
+            guard token != "" else {
+                print("nilnil닐닐")
+                return
+            }
+            print(token)
+        }
     }
     
     @IBAction func signInWithAppleTouched(_ sender: UIButton) {
         // TODO: 애플 로그인 검증
+    }
+}
+
+extension SignInViewController: ASWebAuthenticationPresentationContextProviding {
+    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        return self.view.window ?? ASPresentationAnchor()
     }
 }


### PR DESCRIPTION
## #8 LoginPage 기능 구현 - Sign In with GitHub 구현

### GitHub OAuth
- OAuthManager 클래스 구현
- requestToken 함수 구현
   - ASWebAuthenticationSession 이용
   - callBackURL에서 Token 분리 및 handler를 통해 전달

### SignInViewController
- signInWithGitHubTouched Action 함수 작성
- ASWebAuthenticationPresentationContextProviding delegate 채택

### 코드 구조 개선
- 구현한 부분에 대해 코드 간결화 및 불필요한 코드 정리
- 복잡도 하위모듈 은닉
   - URL extension을 통해 callBackURL의 Token을 찾는 searchToken 함수 구현
- DataFlow
   - OAuthManager를 통해, VC에서 직접 request하는게 아닌, Model을 통해 API 접근